### PR TITLE
refactor to remove python dep and add extra SAs

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,55 +1,66 @@
 terraform {
-	required_providers {
-		aws = {
-			source = "hashicorp/aws"
-			version = "3.11.0"
-		}
-	}
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "3.11.0"
+    }
+  }
 }
 
 provider "aws" {
-	version = "~> 3.11"
-	region  = "ca-central-1"
-	alias   = "master"
-	profile = "sea-terraform-automation"
+  region  = "ca-central-1"
+  alias   = "master"
+  profile = "sea-terraform-automation"
 }
 
 module "lz_info" {
-	source = "github.com/BCDevOps/terraform-aws-sea-organization-info"
-	providers = {
-		aws = aws.master
-	}
+  source = "github.com/BCDevOps/terraform-aws-sea-organization-info"
+  providers = {
+    aws = aws.master
+  }
 }
 
 locals {
-
-	core_accounts = { for account in module.lz_info.core_accounts : account.name =>  account }
-
-	security_account = local.core_accounts[var.iam_security_account_name]
+  core_accounts    = { for account in module.lz_info.core_accounts : account.name => account }
+  security_account = local.core_accounts[var.iam_security_account_name]
+  project_config   = jsondecode(var.project_config)
+  project_accounts = { for account in local.project_config.accounts : account.environment => account }
 }
 
 provider "aws" {
-	version = "~> 3.11"
-	region  = "ca-central-1"
-	alias   = "iam-security-account"
-	profile = "sea-terraform-automation"
+  region  = "ca-central-1"
+  alias   = "iam-security-account"
+  profile = "sea-terraform-automation"
 
-	assume_role {
-		role_arn     = "arn:aws:iam::${local.security_account.id}:role/${var.automation_role_name}"
-		session_name = "slz-terraform-automation"
-	}
+  assume_role {
+    role_arn     = "arn:aws:iam::${local.security_account.id}:role/${var.automation_role_name}"
+    session_name = "slz-terraform-automation"
+  }
 }
 
 resource "aws_iam_user" "terraform_automation_project_user" {
-	provider = aws.iam-security-account
-	name = "BCGOV_Project_Automation_Account_${var.project_name}"
-	path = "/project-service-accounts/"
+  provider = aws.iam-security-account
+  name     = "BCGOV_Project_Automation_Account_${var.project_name}"
+  path     = "/project-service-accounts/"
 }
 
 resource "aws_iam_access_key" "terraform_automation_project_user_access_key" {
-	provider = aws.iam-security-account
-	user = aws_iam_user.terraform_automation_project_user.name
-	pgp_key = var.pgp_key
+  provider = aws.iam-security-account
+  user     = aws_iam_user.terraform_automation_project_user.name
+  pgp_key  = var.pgp_key
 }
 
+resource "aws_iam_user" "extra_project_user" {
+  for_each = toset(var.extra_service_accounts)
+  provider = aws.iam-security-account
+  name     = "BCGOV_Project_User_${each.key}_${var.project_name}"
+  path     = "/project-service-accounts/"
+}
+
+resource "aws_iam_access_key" "extra_project_user_access_key" {
+  for_each = toset(var.extra_service_accounts)
+  provider = aws.iam-security-account
+  user     = aws_iam_user.extra_project_user[each.key].name
+  # pgp_key  = var.pgp_key
+}
 

--- a/main.tf
+++ b/main.tf
@@ -50,17 +50,17 @@ resource "aws_iam_access_key" "terraform_automation_project_user_access_key" {
   pgp_key  = var.pgp_key
 }
 
-resource "aws_iam_user" "extra_project_user" {
-  for_each = toset(var.extra_service_accounts)
+resource "aws_iam_user" "project_user" {
+  for_each = toset(var.project_service_accounts)
   provider = aws.iam-security-account
   name     = "BCGOV_Project_User_${each.key}_${var.project_name}"
   path     = "/project-service-accounts/"
 }
 
-resource "aws_iam_access_key" "extra_project_user_access_key" {
-  for_each = toset(var.extra_service_accounts)
+resource "aws_iam_access_key" "project_user_access_key" {
+  for_each = toset(var.project_service_accounts)
   provider = aws.iam-security-account
-  user     = aws_iam_user.extra_project_user[each.key].name
+  user     = aws_iam_user.project_user[each.key].name
   # pgp_key  = var.pgp_key
 }
 

--- a/modules/roles/main.tf
+++ b/modules/roles/main.tf
@@ -1,0 +1,35 @@
+resource "aws_iam_role" "this" {
+  name               = var.role_name
+  assume_role_policy = <<EOF
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": "sts:AssumeRole",
+      "Principal": {
+        "AWS": "${var.iam_user_arn}"
+      },
+      "Effect": "Allow"
+    }
+  ]
+}
+EOF
+}
+
+resource "aws_iam_policy" "this" {
+  for_each = { for policy in var.policies : policy.name => policy }
+  name     = each.key
+  policy   = jsonencode(each.value.inline_policy)
+}
+
+resource "aws_iam_role_policy_attachment" "policy_arns" {
+  for_each   = toset(var.policy_arns)
+  role       = aws_iam_role.this.name
+  policy_arn = each.key
+}
+
+resource "aws_iam_role_policy_attachment" "policies" {
+  for_each   = aws_iam_policy.this
+  role       = aws_iam_role.this.name
+  policy_arn = aws_iam_policy.this[each.key].arn
+}

--- a/modules/roles/main.tf
+++ b/modules/roles/main.tf
@@ -30,6 +30,6 @@ resource "aws_iam_role_policy_attachment" "policy_arns" {
 
 resource "aws_iam_role_policy_attachment" "policy_json" {
   for_each   = { for policy in aws_iam_policy.this : policy.name => policy.arn }
-  role       = each.key
+  role       = aws_iam_role.this.name
   policy_arn = each.value
 }

--- a/modules/roles/outputs.tf
+++ b/modules/roles/outputs.tf
@@ -1,0 +1,3 @@
+output "role_arn" {
+  value = aws_iam_role.this.arn
+}

--- a/modules/roles/variables.tf
+++ b/modules/roles/variables.tf
@@ -1,5 +1,6 @@
-variable "iam_user_arn" {
-  description = "ARN of AWS IAM user allowed to assume role"
+variable "iam_user_arns" {
+  description = "List of ARNs of AWS IAM user allowed to assume role"
+  type        = list(string)
 }
 
 variable "role_name" {
@@ -12,7 +13,8 @@ variable "policy_arns" {
   default     = []
 }
 
-variable "policies" {
-  description = "List of AWS policies"
-  default     = []
+variable "policy_json" {
+  description = "AWS policy JSON string"
+  type        = string
+  default     = ""
 }

--- a/modules/roles/variables.tf
+++ b/modules/roles/variables.tf
@@ -1,0 +1,18 @@
+variable "iam_user_arn" {
+  description = "ARN of AWS IAM user allowed to assume role"
+}
+
+variable "role_name" {
+  description = "Name of the AWS role to create and attach policy on"
+}
+
+variable "policy_arns" {
+  description = "List of AWS policy ARNs"
+  type        = list(string)
+  default     = []
+}
+
+variable "policies" {
+  description = "List of AWS policies"
+  default     = []
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -7,11 +7,11 @@ output "secret_access_key" {
   value = aws_iam_access_key.terraform_automation_project_user_access_key.encrypted_secret
 }
 
-output "extra_sa_access_keys" {
+output "project_sa_access_keys" {
   value = {
-    for sa in var.extra_service_accounts : sa => {
-      access_key_id     = aws_iam_access_key.extra_project_user_access_key[sa].id
-      access_key_secret = aws_iam_access_key.extra_project_user_access_key[sa].secret
+    for sa in var.project_service_accounts : sa => {
+      access_key_id     = aws_iam_access_key.project_user_access_key[sa].id
+      access_key_secret = aws_iam_access_key.project_user_access_key[sa].secret
     }
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,8 +1,17 @@
 //module outputs should be defined and documented here.
 output "access_key_id" {
-	value = aws_iam_access_key.terraform_automation_project_user_access_key.id
+  value = aws_iam_access_key.terraform_automation_project_user_access_key.id
 }
 
 output "secret_access_key" {
-	value = aws_iam_access_key.terraform_automation_project_user_access_key.encrypted_secret
+  value = aws_iam_access_key.terraform_automation_project_user_access_key.encrypted_secret
+}
+
+output "extra_sa_access_keys" {
+  value = {
+    for sa in var.extra_service_accounts : sa => {
+      access_key_id     = aws_iam_access_key.extra_project_user_access_key[sa].id
+      access_key_secret = aws_iam_access_key.extra_project_user_access_key[sa].secret
+    }
+  }
 }

--- a/variables.tf
+++ b/variables.tf
@@ -11,7 +11,7 @@ variable "project_config" {
   description = "project.json config."
 }
 
-variable "extra_service_accounts" {
+variable "project_service_accounts" {
   type        = list(string)
   description = "A list of names for addtional custom iam user service accounts."
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,19 +1,28 @@
-variable iam_security_account_name {
-    description = "IAM Security Account Name"
-	default = "iam-security"
+variable "iam_security_account_name" {
+  description = "IAM Security Account Name"
+  default     = "iam-security"
 }
 
-variable project_name {
-    description = "Project prefix (aka license plate)."
+variable "project_name" {
+  description = "Project prefix (aka license plate)."
+}
+
+variable "project_config" {
+  description = "project.json config."
+}
+
+variable "extra_service_accounts" {
+  type        = list(string)
+  description = "A list of names for addtional custom iam user service accounts."
 }
 
 variable "automation_role_name" {
-	default = "OrganizationAccountAccessRole"
-	description = "The role used for executing automation commands in the environment."
-	type = string
+  default     = "OrganizationAccountAccessRole"
+  description = "The role used for executing automation commands in the environment."
+  type        = string
 }
 
 variable "pgp_key" {
-	type = string
-	description = "A base64 string containing the pgp key to use to encrypt the secret access key."
+  type        = string
+  description = "A base64 string containing the pgp key to use to encrypt the secret access key."
 }


### PR DESCRIPTION
Closes: bcgov/cloud-pathfinder#663
Depends on: bcgov-c/aws-lz2-workspaces-live#4

- Refactors module to support automation layer refactor in PR bcgov-c/aws-lz2-workspaces-live#4
- Adds support for creating extra service account