### PR TITLE
added kms policy GenerateDataKey to the UMS permission boundary

### DIFF
--- a/modules/iam-users/main.tf
+++ b/modules/iam-users/main.tf
@@ -244,7 +244,8 @@ resource "aws_iam_policy" "s3_full_access_boundary" {
       "Effect": "Allow",
       "Action": [
         "kms:Decrypt",
-        "kms:Encrypt"
+        "kms:Encrypt",
+        "kms:GenerateDataKey"
       ],
       "Resource": "arn:aws:kms:*:*:key/*"
     },


### PR DESCRIPTION
Looked good in the tg plan, do we need to do any version changes to implement this? 